### PR TITLE
Simplify and fix initialization and TUIState usage

### DIFF
--- a/BasicApp.lpr
+++ b/BasicApp.lpr
@@ -32,4 +32,6 @@ begin
     without any extra output on Unix.
     This also allows to set --log-file from Application.ParseStandardParameters. }
   InitializeLog;
+  
+  Application.MainWindow.OpenAndRun;
 end.

--- a/gameinitialize.pas
+++ b/gameinitialize.pas
@@ -8,18 +8,17 @@ uses
   CastleWindow, CastleScene, CastleControls, CastleLog, CastleUIState, 
   CastleTimeUtils, CastleApplicationProperties, MainGameUnit;
 
-var
-  Window: TCastleWindowBase;
-  CastleApp: TCastleApp;
+procedure ApplicationInitialize;
 
 implementation
+
+var
+  Window: TCastleWindowBase;
 
 { One-time initialization of resources. }
 procedure ApplicationInitialize;
 begin
-  GLIsReady := False;
-  Window.onClose := @WindowClose;
-  Window.onOpen := @WindowOpen;
+  GLIsReady := true;
   CastleApp := TCastleApp.Create(Application);
   TUIState.Current := CastleApp;
 end;
@@ -51,7 +50,5 @@ initialization
     In particular, it is not allowed to read files before ApplicationInitialize
     (because in case of non-desktop platforms,
     some necessary resources may not be prepared yet). }
-
-  Application.MainWindow.OpenAndRun;
 end.
 

--- a/maingameunit.pas
+++ b/maingameunit.pas
@@ -58,10 +58,6 @@ var
   CastleForm: TCastleForm;
 {$endif}
 
-{$ifdef cgeapp}
-procedure WindowClose(Sender: TUIContainer);
-procedure WindowOpen(Sender: TUIContainer);
-{$endif}
 
 implementation
 {$ifdef cgeapp}
@@ -99,6 +95,7 @@ end;
 
 procedure TCastleApp.Start;
 begin
+  inherited;
   Scene := nil;
 //  UIScaling := usDpiScale;
   LoadScene('castle-data:/box_roty.x3dv');
@@ -106,6 +103,7 @@ end;
 
 procedure TCastleApp.Stop;
 begin
+  inherited;
 end;
 
 
@@ -122,36 +120,18 @@ end;
 procedure TCastleForm.FormDestroy(Sender: TObject);
 begin
 end;
-{$endif}
 
-{$ifdef cgeapp}
-procedure WindowOpen(Sender: TUIContainer);
-{$else}
 procedure TCastleForm.WindowOpen(Sender: TObject);
-{$endif}
 begin
   GLIsReady := True;
-  {$ifndef cgeapp}
   TCastleControlBase.MainControl := Window;
-  CastleApp := TCastleApp.Create(Application);
-  TUIState.Current := CastleApp;
-  CastleApp.Start;
-  {$else}
-  // Duplicated from ApplicationInitialize (still breaks)
-  if Application.MainWindow = nil then
-    Application.MainWindow := Window;
-  CastleApp := TCastleApp.Create(Application);
-  TUIState.Current := CastleApp;
-  {$endif}
+  ApplicationInitialize;
 end;
 
-{$ifdef cgeapp}
-procedure WindowClose(Sender: TUIContainer);
-{$else}
 procedure TCastleForm.WindowClose(Sender: TObject);
-{$endif}
 begin
 end;
+{$endif}
 
 procedure TCastleApp.BeforeRender;
 const
@@ -160,30 +140,31 @@ const
 var
   theta: Single;
 begin
-  if GLIsReady then
-    begin
-    // Set angle (theta) to revolve completely once every SecsPerRot
-    theta := ((CastleGetTickCount64 mod
-              (SecsPerRot * 1000)) /
-              (SecsPerRot * 1000)) * (Pi * 2);
+  inherited;
+  // Set angle (theta) to revolve completely once every SecsPerRot
+  theta := ((CastleGetTickCount64 mod
+            (SecsPerRot * 1000)) /
+            (SecsPerRot * 1000)) * (Pi * 2);
 
-    // Rotate the scene in Y
-    // Change to Vector4(1, 0, 0, theta); to rotate in X
+  // Rotate the scene in Y
+  // Change to Vector4(1, 0, 0, theta); to rotate in X
 
-    Scene.Rotation := Vector4(0, 1, 0, theta);
-    end;
+  Scene.Rotation := Vector4(0, 1, 0, theta);
 end;
 
 procedure TCastleApp.Render;
 begin
+  inherited;
 end;
 
 procedure TCastleApp.Resize;
 begin
+  inherited;
 end;
 
 procedure TCastleApp.Update(const SecondsPassed: Single; var HandleInput: boolean);
 begin
+  inherited;
 end;
 
 function TCastleApp.Motion(const Event: TInputMotion): Boolean;


### PR DESCRIPTION
- Inside Application.OnInitialize, you know that `GLIsReady` is `true`

- You don't need WindowOpen or WindowClose at all in case of TCastleWindowBase, most of the time

- In WindowOpen: fix repeating the initialization that was already done in `ApplicationInitialize`

- Avoid 2 variables `CastleApp`

- Do not call `CastleApp.Start` explicitly. This is done automatically by `TUIState.Current := CastleApp`

- Bette to move `Application.MainWindow.OpenAndRun` to BasicApp.lpr (TCastleWindowBase lpr), it should be done after parsing command-line parameters ideally.

- Use `inherited` in all overridden methods.